### PR TITLE
Remove remark about lack of a GUI for NanoBoyAdvance

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Contribute adding resources or providing feedback through Pull Requests, Issues 
 
 - [mGBA](https://mgba.io) - Actively developed GBA emulator. Runs on a bunch of platforms. Text debugger through GDB stub.
 - [No$gba](https://problemkaputt.de/gba.htm) - Venerable GBA emulator. Windows only, but runs well under Wine. Not very actively maintained but still gets updates now and then. Sports graphical debugger.
-- [NanoBoyAdvance](https://github.com/fleroviux/NanoBoyAdvance) - GBA emulator with high accuracy, especially in timing and CPU emulation. Currently lacking a GUI or debugger.
+- [NanoBoyAdvance](https://github.com/nba-emu/NanoBoyAdvance) - GBA emulator with high accuracy, especially in timing and CPU emulation. Does not have debugging features.
 - [MiSTer FPGA implementation](https://github.com/MiSTer-devel/GBA_MiSTer) - Needs [MiSTer](https://github.com/MiSTer-devel/Main_MiSTer/wiki) setup to run.
 
 # Emulator Development


### PR DESCRIPTION
NanoBoyAdvance didn't have a GUI when I added it to the list, but it now does.
I've also updated the URL as the repository is now under a GitHub organization.